### PR TITLE
DoH cleanup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "pdns/dnsdistdist/ext/h2o"]
-	path = pdns/dnsdistdist/ext/h2o
-	url = https://github.com/h2o/h2o.git

--- a/pdns/dnsdist-lua.cc
+++ b/pdns/dnsdist-lua.cc
@@ -42,7 +42,9 @@
 #include "lock.hh"
 #include "protobuf.hh"
 #include "sodcrypto.hh"
+#ifdef HAVE_DNS_OVER_HTTPS
 #include "doh.hh"
+#endif
 #include <boost/logic/tribool.hpp>
 
 #ifdef HAVE_SYSTEMD
@@ -1478,7 +1480,7 @@ void setupLuaConfig(bool client)
   g_lua.writeFunction("addDOHLocal", [client](const std::string& addr, const std::string& certFile, const std::string& keyFile, boost::optional<vector<pair<int, std::string> > > urls, boost::optional<localbind_t> vars) {
         if (client)
           return;
-
+#ifdef HAVE_DNS_OVER_HTTPS
         setLuaSideEffect();
         if (g_configurationDone) {
           g_outputBuffer="addDOHLocal cannot be used at runtime!\n";
@@ -1499,6 +1501,9 @@ void setupLuaConfig(bool client)
           cout << "Not yet processing variables!" << endl;
         }
         g_dohlocals.push_back(frontend);
+#else
+        g_outputBuffer="DNS over HTTPS support is not present!\n";
+#endif
       });
 
   g_lua.writeFunction("addTLSLocal", [client](const std::string& addr, boost::variant<std::string, std::vector<std::pair<int,std::string>>> certFiles, boost::variant<std::string, std::vector<std::pair<int,std::string>>> keyFiles, boost::optional<localbind_t> vars) {

--- a/pdns/dnsdist.cc
+++ b/pdns/dnsdist.cc
@@ -30,7 +30,9 @@
 #include <pwd.h>
 #include <sys/resource.h>
 #include <unistd.h>
+#ifdef HAVE_DNS_OVER_HTTPS
 #include "doh.hh"
+#endif
 
 #if defined (__OpenBSD__) || defined(__NetBSD__)
 #include <readline/readline.h>
@@ -91,7 +93,9 @@ string g_outputBuffer;
 
 vector<std::tuple<ComboAddress, bool, bool, int, string, std::set<int>>> g_locals;
 std::vector<std::shared_ptr<TLSFrontend>> g_tlslocals;
+#ifdef HAVE_DNS_OVER_HTTPS
 std::vector<std::shared_ptr<DOHFrontend>> g_dohlocals;
+#endif
 #ifdef HAVE_DNSCRYPT
 std::vector<std::tuple<ComboAddress,std::shared_ptr<DNSCryptContext>,bool, int, string, std::set<int> >> g_dnsCryptLocals;
 #endif
@@ -2671,10 +2675,12 @@ try
     }
   }
 
+#ifdef HAVE_DNS_OVER_HTTPS
   for(auto& df : g_dohlocals) {
     thread dohthread(dohThread, df->d_local, df->d_urls, df->d_certFile, df->d_keyFile);
     dohthread.detach();
   }
+#endif
   
   thread carbonthread(carbonDumpThread);
   carbonthread.detach();

--- a/pdns/dnsdist.hh
+++ b/pdns/dnsdist.hh
@@ -41,7 +41,9 @@
 #include <string>
 #include <unordered_map>
 #include "tcpiohandler.hh"
+#ifdef HAVE_DNS_OVER_HTTPS
 #include "doh.hh"
+#endif
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
@@ -834,7 +836,9 @@ extern ComboAddress g_serverControl; // not changed during runtime
 
 extern std::vector<std::tuple<ComboAddress, bool, bool, int, std::string, std::set<int>>> g_locals; // not changed at runtime (we hope XXX)
 extern std::vector<shared_ptr<TLSFrontend>> g_tlslocals;
+#ifdef HAVE_DNS_OVER_HTTPS
 extern std::vector<shared_ptr<DOHFrontend>> g_dohlocals;
+#endif
 extern vector<ClientState*> g_frontends;
 extern bool g_truncateTC;
 extern bool g_fixupCase;

--- a/pdns/dnsdistdist/Makefile.am
+++ b/pdns/dnsdistdist/Makefile.am
@@ -1,4 +1,4 @@
-AM_CPPFLAGS += $(SYSTEMD_CFLAGS) $(LUA_CFLAGS) $(LIBEDIT_CFLAGS) $(LIBSODIUM_CFLAGS) $(FSTRM_CFLAGS) $(YAHTTP_CFLAGS) $(SANITIZER_FLAGS) $(NET_SNMP_CFLAGS) -DSYSCONFDIR=\"${sysconfdir}\" -Iext/h2o-2.2.5/include/
+AM_CPPFLAGS += $(SYSTEMD_CFLAGS) $(LUA_CFLAGS) $(LIBEDIT_CFLAGS) $(LIBSODIUM_CFLAGS) $(FSTRM_CFLAGS) $(YAHTTP_CFLAGS) $(SANITIZER_FLAGS) $(NET_SNMP_CFLAGS) -DSYSCONFDIR=\"${sysconfdir}\"
 
 ACLOCAL_AMFLAGS = -I m4
 
@@ -41,6 +41,16 @@ endif
 
 if HAVE_GNUTLS
 AM_CPPFLAGS += $(GNUTLS_CFLAGS)
+endif
+endif
+
+if HAVE_DNS_OVER_HTTPS
+if HAVE_LIBH2OEVLOOP
+AM_CPPFLAGS += $(LIBH2OEVLOOP_CFLAGS)
+endif
+
+if HAVE_LIBSSL
+AM_CPPFLAGS += $(LIBSSL_CFLAGS)
 endif
 endif
 
@@ -87,7 +97,6 @@ dnsdist_SOURCES = \
 	base64.hh \
 	bpf-filter.cc bpf-filter.hh \
 	cachecleaner.hh \
-	doh.cc doh.hh \
 	dns.cc dns.hh \
 	dnscrypt.cc dnscrypt.hh \
 	dnsdist.cc dnsdist.hh \
@@ -160,8 +169,7 @@ dnsdist_LDADD = \
 	$(FSTRM_LIBS) \
 	$(SANITIZER_FLAGS) \
 	$(SYSTEMD_LIBS) \
-	$(NET_SNMP_LIBS) \
-	ext/h2o-2.2.5/build/libh2o-evloop.a -lz
+	$(NET_SNMP_LIBS)
 
 if HAVE_RE2
 dnsdist_LDADD += $(RE2_LIBS)
@@ -174,6 +182,18 @@ endif
 
 if HAVE_LIBSSL
 dnsdist_LDADD += $(LIBSSL_LIBS) $(LIBCRYPTO_LIBS)
+endif
+endif
+
+if HAVE_DNS_OVER_HTTPS
+dnsdist_SOURCES += doh.hh doh.cc
+
+if HAVE_LIBH2OEVLOOP
+dnsdist_LDADD += $(LIBH2OEVLOOP_LIBS)
+endif
+
+if HAVE_LIBSSL
+dnsdist_LDADD += $(LIBSSL_LIBS)
 endif
 endif
 

--- a/pdns/dnsdistdist/configure.ac
+++ b/pdns/dnsdistdist/configure.ac
@@ -58,6 +58,17 @@ AS_IF([test "x$enable_dns_over_tls" != "xno"], [
   ])
 ])
 
+DNSDIST_ENABLE_DNS_OVER_HTTPS
+PDNS_CHECK_LIBH2OEVLOOP
+AS_IF([test "x$enable_dns_over_https" != "xno"], [
+  AS_IF([test "$HAVE_LIBH2OEVLOOP" = "0"], [
+    AC_MSG_ERROR([DNS over HTTPS support requested but libh2o-evloop was not found])
+  ])
+  AS_IF([test "$HAVE_LIBSSL" = "0"], [
+    AC_MSG_ERROR([DNS over HTTPS support requested but OpenSSL was not found])
+  ])
+])
+
 AX_CXX_COMPILE_STDCXX_11([ext], [mandatory])
 
 AC_MSG_CHECKING([whether we will enable compiler security checks])
@@ -159,5 +170,9 @@ AS_IF([test "x$GNUTLS_LIBS" != "x"],
 AS_IF([test "x$LIBSSL_LIBS" != "x"],
   [AC_MSG_NOTICE([OpenSSL: yes])],
   [AC_MSG_NOTICE([OpenSSL: no])]
+)
+AS_IF([test "x$enable_dns_over_https" != "xno"],
+  [AC_MSG_NOTICE([DNS over HTTPS (DoH): yes])],
+  [AC_MSG_NOTICE([DNS over HTTPS (DoH): no])]
 )
 AC_MSG_NOTICE([])

--- a/pdns/dnsdistdist/m4/dnsdist_enable_doh.m4
+++ b/pdns/dnsdistdist/m4/dnsdist_enable_doh.m4
@@ -1,0 +1,15 @@
+AC_DEFUN([DNSDIST_ENABLE_DNS_OVER_HTTPS], [
+  AC_MSG_CHECKING([whether to enable DNS over HTTPS (DoH) support])
+  AC_ARG_ENABLE([dns-over-https],
+    AS_HELP_STRING([--enable-dns-over-https], [enable DNS over HTTPS (DoH) support (requires libh2o) @<:@default=no@:>@]),
+    [enable_dns_over_https=$enableval],
+    [enable_dns_over_https=no]
+  )
+  AC_MSG_RESULT([$enable_dns_over_https])
+  AM_CONDITIONAL([HAVE_DNS_OVER_HTTPS], [test "x$enable_dns_over_https" != "xno"])
+
+  AM_COND_IF([HAVE_DNS_OVER_HTTPS], [
+    AC_DEFINE([HAVE_DNS_OVER_HTTPS], [1], [Define to 1 if you enable DNS over HTTPS support])
+  ])
+])
+

--- a/pdns/dnsdistdist/m4/pdns_check_libh2o_evloop.m4
+++ b/pdns/dnsdistdist/m4/pdns_check_libh2o_evloop.m4
@@ -1,0 +1,8 @@
+AC_DEFUN([PDNS_CHECK_LIBH2OEVLOOP], [
+  HAVE_LIBH2OEVLOOP=0
+  PKG_CHECK_MODULES([LIBH2OEVLOOP], [libh2o-evloop], [
+    [HAVE_LIBH2OEVLOOP=1]
+    AC_DEFINE([HAVE_LIBH2OEVLOOP], [1], [Define to 1 if you have libh2o-evloop])
+  ], [ : ])
+  AM_CONDITIONAL([HAVE_LIBH2OEVLOOP], [test "x$LIBH2OEVLOOP_LIBS" != "x"])
+])


### PR DESCRIPTION
### Short description

 * Add configure flag `--enable-dns-over-https` to enable DoH
 * Add pkg-config detection for `libh2o-evloop`
 * Ensure dnsdist can be built _without_ DoH
 * Remove the h2o directory/submodule

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [ ] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled and tested this code
- [ ] included documentation (including possible behaviour changes)
- [ ] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
- [ ] <!-- remove this line if your PR is against master --> checked that this code was merged to master
